### PR TITLE
Mark as unmaintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # pypistats
 
+**No longer maintained:** This package is no longer maintained as the PyPI Stats endpoint was not rebuilt in Warehouse. Instead, see the [Analyzing PyPI package downloads](https://packaging.python.org/guides/analyzing-pypi-package-downloads/) page.
+
 Client to parse out stats from PyPI Stats endpoint
 
 Simple CLI to today can:


### PR DESCRIPTION
It seems this would no longer work as `/stats` is gone, so mark as such.